### PR TITLE
chore: Add Claude Code launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Vite Dev Server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "Vite Preview Server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 4173
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `.claude/launch.json` 추가 — Vite Dev Server(5173) 및 Preview Server(4173) 설정
- Claude Code 프로젝트 메모리 파일 추가

## Test plan
- [ ] `npm run dev` 정상 실행 확인 (포트 5173)
- [ ] `npm run preview` 정상 실행 확인 (포트 4173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)