### PR TITLE
fix: 비밀 업적 리스트 표시 및 강조 (#31)

### DIFF
--- a/src/components/AchievementsModal.jsx
+++ b/src/components/AchievementsModal.jsx
@@ -79,23 +79,32 @@ export function AchievementsModal({ onClose, unlockedIds, lang }) {
               </div>
               {items.map(ach => {
                 const unlocked = unlockedIds.has(ach.id)
+                const isSecret = !!ach.hidden
+                const isSecretLocked = isSecret && !unlocked
+                const isSecretUnlocked = isSecret && unlocked
                 const expanded = expandedId === ach.id
                 const name = ach.name?.[lang] || ach.name?.ko
                 const desc = ach.desc?.[lang] || ach.desc?.ko
                 const stars = Math.ceil(ach.difficulty / 2)
+                const secretLabel = lang === 'ko' ? '비밀 업적' : lang === 'ja' ? '秘密実績' : lang === 'zh' ? '秘密成就' : 'Secret Achievement'
+                const secretHint = lang === 'ko' ? '잠금 해제 후 공개됩니다' : lang === 'ja' ? '解除後に公開されます' : lang === 'zh' ? '解锁后公开' : 'Revealed after unlocking'
                 return (
                   <div
                     key={ach.id}
-                    className={`ach-list-item ${unlocked ? 'unlocked' : 'locked'} ${expanded ? 'expanded' : ''}`}
+                    className={`ach-list-item ${unlocked ? 'unlocked' : 'locked'} ${isSecretUnlocked ? 'secret-unlocked' : ''} ${expanded ? 'expanded' : ''}`}
                     onClick={() => toggle(ach.id)}
                   >
                     <div className="ach-list-row">
                       <div className={`ach-list-icon ${unlocked ? '' : 'locked-icon'}`}>
-                        {unlocked ? ach.icon : '🔒'}
+                        {isSecretLocked ? '🔒' : unlocked ? ach.icon : '🔒'}
                       </div>
                       <div className="ach-list-info">
                         <div className="ach-list-name">
-                          {name} {!unlocked && <span className="locked-badge">🔒</span>}
+                          {isSecretLocked
+                            ? <span className="ach-secret-label">{secretLabel}</span>
+                            : <>{name} {isSecretUnlocked && <span className="ach-secret-badge">✨</span>}</>
+                          }
+                          {!unlocked && !isSecretLocked && <span className="locked-badge">🔒</span>}
                         </div>
                         <div className="ach-list-stars">
                           {'★'.repeat(stars)}{'☆'.repeat(5 - stars)}
@@ -105,8 +114,14 @@ export function AchievementsModal({ onClose, unlockedIds, lang }) {
                     </div>
                     {expanded && (
                       <div className="ach-list-detail">
-                        <div className="ach-list-real-name">{name}</div>
-                        <div className="ach-list-desc">{desc}</div>
+                        {isSecretLocked ? (
+                          <div className="ach-list-desc ach-secret-hint">{secretHint}</div>
+                        ) : (
+                          <>
+                            <div className="ach-list-real-name">{name}</div>
+                            <div className="ach-list-desc">{desc}</div>
+                          </>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3233,6 +3233,24 @@ body.modal-open { overflow: hidden; }
   color: var(--color-on-surface-variant);
   line-height: 1.5;
 }
+.ach-list-item.secret-unlocked {
+  background: linear-gradient(135deg, rgba(255,215,0,0.15), var(--color-surface-container));
+  border: 1px solid rgba(255,215,0,0.4);
+  opacity: 1;
+}
+.ach-secret-label {
+  color: var(--color-on-surface-variant);
+  font-style: italic;
+  letter-spacing: 0.02em;
+}
+.ach-secret-badge {
+  font-style: normal;
+  margin-left: 4px;
+}
+.ach-secret-hint {
+  font-style: italic;
+  opacity: 0.7;
+}
 
 /* ─── Notification Bell ─── */
 .notification-btn-wrap {


### PR DESCRIPTION
## Summary
- Closes #31

## Changes
- 비밀 업적(hidden: true)을 업적 전체 리스트에 포함하여 카운트에 반영 (기존: 완전히 숨김)
- 미해제 비밀 업적: 아이콘 🔒, 이름 "비밀 업적"으로 표시, 클릭 시 "잠금 해제 후 공개됩니다" 안내
- 해제된 비밀 업적: 골드 그라디언트 배경 + ✨ 뱃지로 강조 표시
- CSS 추가: `.ach-list-item.secret-unlocked`, `.ach-secret-label`, `.ach-secret-badge`, `.ach-secret-hint`

🤖 Auto-fixed by scheduled agent