### PR TITLE
feat: 태블릿 반응형 레이아웃 (split-pane) (#30)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3914,3 +3914,81 @@ body.modal-open { overflow: hidden; }
   width: 22px;
   height: 22px;
 }
+
+/* ═══════════════════════════════════════════════
+   Tablet Layout — split-pane (min-width: 600px)
+   ═══════════════════════════════════════════════ */
+@media (min-width: 600px) {
+  /* Center the app shell */
+  #root {
+    display: flex;
+    justify-content: center;
+    background: var(--color-surface-container-low);
+    min-height: 100vh;
+  }
+
+  /* Card becomes horizontal split-pane */
+  .card {
+    flex-direction: row;
+    align-items: stretch;
+    max-width: 960px;
+    width: 100%;
+    height: 100vh;
+    border-radius: 0;
+  }
+
+  /* Left sidebar: header nav panel */
+  .header-wrapper {
+    width: 300px;
+    flex-shrink: 0;
+    height: 100vh;
+    overflow-y: auto;
+    border-right: 1px solid var(--color-outline-variant);
+    padding: 0 16px;
+    padding-top: max(20px, env(safe-area-inset-top));
+    /* Sidebar stays in place while content scrolls */
+    position: sticky;
+    top: 0;
+  }
+
+  /* Right pane: scrollable todo list */
+  .todo-list-section {
+    flex: 1;
+    height: 100vh;
+    overflow-y: auto;
+    padding: 24px 28px;
+    padding-bottom: calc(90px + env(safe-area-inset-bottom));
+  }
+
+  /* Bottom nav: constrained to card width, centered */
+  .bottom-nav {
+    max-width: 960px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: 0 24px 0 0;
+    right: auto;
+    width: 960px;
+  }
+
+  /* FAB: pin to right side of content pane */
+  .fab {
+    right: calc(50% - 960px / 2 + 28px);
+  }
+
+  /* Modal overlays: cover full viewport */
+  .modal-overlay {
+    position: fixed;
+    left: 0;
+    right: 0;
+  }
+
+  /* Sidebar header reduces its bottom padding (no bottom-nav clearance needed) */
+  .header {
+    padding-bottom: 20px;
+  }
+
+  /* Larger todo cards on tablet */
+  .todo-card {
+    padding: 18px 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #30

## Changes
- `src/index.css`에 `@media (min-width: 600px)` 태블릿 레이아웃 추가
- `.card`를 `flex-direction: row`로 변환 → 좌측 사이드바 + 우측 콘텐츠 split-pane
- 좌측 사이드바(`.header-wrapper`): 너비 300px, sticky, 날짜 네비·태그 필터 포함
- 우측 콘텐츠(`.todo-list-section`): flex: 1, 독립 스크롤
- 전체 앱 최대 너비 960px, 화면 중앙 정렬
- BottomNav 위치 960px 안으로 제한
- FAB 위치 콘텐츠 영역 기준으로 조정
- 모달 오버레이 전체 뷰포트 커버 유지

🤖 Auto-fixed by scheduled agent