### PR TITLE
fix: 알림 영속성 개선 — BootReceiver + 배터리 최적화 대응

### DIFF
--- a/PROJECT_HISTORY.md
+++ b/PROJECT_HISTORY.md
@@ -4,6 +4,38 @@
 
 ---
 
+## 2026-04-12 — 알림 영속성 개선: BootReceiver + 배터리 최적화 대응 (세션 46)
+
+### 변경 내용
+
+#### 기기 재시작 후 상태바 알림 서비스 자동 복원 (Issue: 재시작 후 알림 소멸)
+- `BootReceiver.java` 신규 생성 — `BOOT_COMPLETED` / `QUICKBOOT_POWERON` 수신 후
+  SharedPreferences의 `enabled=true` 값 확인 시 `StatusBarNotificationService` 자동 재시작
+- `AndroidManifest.xml` — BootReceiver 등록 (exported=true, BOOT_COMPLETED/QUICKBOOT_POWERON)
+- `StatusBarNotificationPlugin.start()` — SharedPreferences에 `enabled=true` 저장
+- `StatusBarNotificationPlugin.stop()` — SharedPreferences에 `enabled=false` 저장
+
+#### 상태바 알림 텍스트 간헐적 초기화 버그 수정
+- `StatusBarNotificationPlugin.updateContent()` — 알림 본문을 SharedPreferences에도 저장
+- `StatusBarNotificationService.onCreate()` — 프로세스 재시작(배터리 최적화 강제 종료 후
+  START_STICKY 복원 포함) 시 SharedPreferences에서 마지막 텍스트(날씨 등) 복원
+- 날씨 선택 후 폰 재시작해도 앱 열리기 전까지 마지막 날씨 텍스트 유지
+
+#### 배터리 최적화 예외 요청 (제조사 커스텀 최적화 대응)
+- `AndroidManifest.xml` — `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 권한 추가
+- `StatusBarNotificationPlugin.requestIgnoreBatteryOptimizations()` 메서드 추가 — 이미 예외 처리된
+  경우 다이얼로그 없이 즉시 반환; 미등록 기기는 시스템 다이얼로그 표시
+- `StatusBarNotificationPlugin.isIgnoringBatteryOptimizations()` 메서드 추가
+- `App.jsx` — 상태바 알림 활성화 시 배터리 최적화 예외 요청 호출
+- `App.jsx` — 앱 최초 1회(`briodo-batteryOptAsked` 플래그) 기존 사용자 포함 자동 요청
+
+#### 일정 푸시 알림 안정성
+- Capacitor `LocalNotifications` 플러그인의 내장 BootReceiver가 재부팅 후 AlarmManager 알림을
+  자동 재스케줄링함 (기존 `allowWhileIdle: true` 유지로 Doze 모드 대응 이미 완료)
+- 배터리 최적화 예외 등록으로 AlarmManager 알람 차단 가능성 추가 감소
+
+---
+
 ## 2026-04-11 — v1.0.8: AI 브리핑 + 가로 3열 레이아웃 + 버그 수정 (세션 45)
 
 ### 변경 내용

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <!-- 상태바 알림 손전등 버튼 -->
     <uses-permission android:name="android.permission.FLASHLIGHT" />
+    <!-- 배터리 최적화 예외 요청 (상태바 알림 서비스 유지, 일정 알림 정시 발송) -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
         android:allowBackup="false"
@@ -74,6 +76,14 @@
                 <action android:name="app.briodo.ACTION_TOGGLE_FLASHLIGHT" />
                 <action android:name="app.briodo.ACTION_ADD_SCHEDULE" />
                 <action android:name="app.briodo.ACTION_NOTIF_DISMISSED" />
+            </intent-filter>
+        </receiver>
+
+        <!-- 기기 재시작 후 상태바 알림 서비스 자동 복원 -->
+        <receiver android:name=".BootReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
 

--- a/android/app/src/main/java/app/briodo/BootReceiver.java
+++ b/android/app/src/main/java/app/briodo/BootReceiver.java
@@ -1,0 +1,39 @@
+package app.briodo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+
+/**
+ * 기기 재시작 후 상태바 알림 서비스 자동 복원.
+ *
+ * RECEIVE_BOOT_COMPLETED 권한은 AndroidManifest에 이미 선언되어 있음.
+ * enabled=true 로 저장된 경우에만 서비스를 재시작한다 (사용자가 명시적으로
+ * 비활성화한 경우에는 부팅 후 자동 시작하지 않음).
+ */
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        // 일반 부팅 + 빠른 부팅(일부 제조사) 모두 처리
+        if (!Intent.ACTION_BOOT_COMPLETED.equals(action) &&
+            !"android.intent.action.QUICKBOOT_POWERON".equals(action)) {
+            return;
+        }
+
+        SharedPreferences prefs = context.getSharedPreferences(
+            StatusBarNotificationService.PREFS_NAME, Context.MODE_PRIVATE);
+        boolean enabled = prefs.getBoolean(StatusBarNotificationService.PREF_ENABLED, false);
+
+        if (!enabled) return;
+
+        Intent svc = new Intent(context, StatusBarNotificationService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(svc);
+        } else {
+            context.startService(svc);
+        }
+    }
+}

--- a/android/app/src/main/java/app/briodo/StatusBarNotificationPlugin.java
+++ b/android/app/src/main/java/app/briodo/StatusBarNotificationPlugin.java
@@ -2,7 +2,10 @@ package app.briodo;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Build;
+import android.os.PowerManager;
+import android.provider.Settings;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -36,6 +39,10 @@ public class StatusBarNotificationPlugin extends Plugin {
     public void start(PluginCall call) {
         String tapAction = call.getString("tapAction", StatusBarNotificationService.TAP_ACTION_APP);
         saveTapAction(tapAction);
+        // BootReceiver가 재시작 여부를 판단할 수 있도록 enabled 상태를 저장
+        getContext().getSharedPreferences(
+            StatusBarNotificationService.PREFS_NAME, android.content.Context.MODE_PRIVATE
+        ).edit().putBoolean(StatusBarNotificationService.PREF_ENABLED, true).apply();
 
         Intent svc = new Intent(getContext(), StatusBarNotificationService.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -49,6 +56,10 @@ public class StatusBarNotificationPlugin extends Plugin {
     // ── 서비스 중지 ───────────────────────────────────────────────────────────
     @PluginMethod
     public void stop(PluginCall call) {
+        // 사용자가 명시적으로 비활성화 → 부팅 후 자동 시작 안 함
+        getContext().getSharedPreferences(
+            StatusBarNotificationService.PREFS_NAME, android.content.Context.MODE_PRIVATE
+        ).edit().putBoolean(StatusBarNotificationService.PREF_ENABLED, false).apply();
         getContext().stopService(new Intent(getContext(), StatusBarNotificationService.class));
         call.resolve();
     }
@@ -94,9 +105,53 @@ public class StatusBarNotificationPlugin extends Plugin {
     public void updateContent(PluginCall call) {
         String text = call.getString("text", null);
         StatusBarNotificationService.notifContentText = text;
+        // SharedPreferences에도 저장 → 프로세스 재시작(배터리 최적화 종료 후 START_STICKY 복원,
+        // BootReceiver 기동) 시 마지막 텍스트를 복원할 수 있도록
+        if (text != null) {
+            getContext().getSharedPreferences(
+                StatusBarNotificationService.PREFS_NAME, android.content.Context.MODE_PRIVATE
+            ).edit().putString(StatusBarNotificationService.PREF_CONTENT_TEXT, text).apply();
+        }
         StatusBarNotificationService svc = getRunningService();
         if (svc != null) svc.refresh();
         call.resolve();
+    }
+
+    // ── 배터리 최적화 예외 요청 ────────────────────────────────────────────────
+    /** 현재 이미 예외 처리된 경우 다이얼로그를 띄우지 않음 */
+    @PluginMethod
+    public void requestIgnoreBatteryOptimizations(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            call.resolve(); // Android 6 미만은 불필요
+            return;
+        }
+        PowerManager pm = (PowerManager) getContext().getSystemService(android.content.Context.POWER_SERVICE);
+        if (pm != null && !pm.isIgnoringBatteryOptimizations(getContext().getPackageName())) {
+            try {
+                Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+                intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                getContext().startActivity(intent);
+            } catch (Exception e) {
+                // 일부 기기에서 인텐트 미지원 시 무시
+            }
+        }
+        call.resolve();
+    }
+
+    /** 현재 배터리 최적화 예외 여부 반환 */
+    @PluginMethod
+    public void isIgnoringBatteryOptimizations(PluginCall call) {
+        boolean ignoring = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PowerManager pm = (PowerManager) getContext().getSystemService(android.content.Context.POWER_SERVICE);
+            if (pm != null) ignoring = pm.isIgnoringBatteryOptimizations(getContext().getPackageName());
+        } else {
+            ignoring = true; // Android 6 미만은 최적화 개념 없음 → 항상 true
+        }
+        JSObject ret = new JSObject();
+        ret.put("value", ignoring);
+        call.resolve(ret);
     }
 
     /** MainActivity에서 호출 — JS로 openSmartInput 이벤트 발사 */

--- a/android/app/src/main/java/app/briodo/StatusBarNotificationService.java
+++ b/android/app/src/main/java/app/briodo/StatusBarNotificationService.java
@@ -31,10 +31,11 @@ public class StatusBarNotificationService extends Service {
     // 일정 추가 탭 동작 — MainActivity로 전달하는 extra
     static final String EXTRA_OPEN_INPUT = "briodo_open_input";
 
-    // SharedPreferences 키 (StatusBarNotificationPlugin과 공유)
+    // SharedPreferences 키 (StatusBarNotificationPlugin / BootReceiver와 공유)
     static final String PREFS_NAME        = "briodo_statusbar_notif";
     static final String PREF_ENABLED      = "enabled";
     static final String PREF_TAP_ACTION   = "tap_action";
+    static final String PREF_CONTENT_TEXT = "content_text"; // 마지막 알림 본문 (프로세스 재시작 후 복원)
     static final String TAP_ACTION_INPUT  = "input";   // SmartInputModal 열기
     static final String TAP_ACTION_APP    = "app";     // 메인 화면 열기 (기본)
 
@@ -51,6 +52,13 @@ public class StatusBarNotificationService extends Service {
     public void onCreate() {
         super.onCreate();
         instance = this;
+        // 프로세스 재시작(배터리 최적화로 인한 종료 + START_STICKY 복원, BootReceiver 기동) 시
+        // 정적 필드 notifContentText가 null로 초기화되므로 SharedPreferences에서 복원한다.
+        if (notifContentText == null) {
+            String saved = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                .getString(PREF_CONTENT_TEXT, null);
+            if (saved != null && !saved.isEmpty()) notifContentText = saved;
+        }
         createChannel();
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -480,6 +480,11 @@ function App() {
     localStorage.setItem('briodo-statusBarNotifEnabled', String(val))
     if (val) {
       StatusBarNotifNative?.start({}).catch(() => {})
+      // 상태바 알림 서비스가 배터리 최적화로 종료되지 않도록 예외 등록 요청
+      // 이미 등록된 경우 다이얼로그 없이 즉시 반환됨
+      if (Capacitor.isNativePlatform()) {
+        StatusBarNotifNative?.requestIgnoreBatteryOptimizations?.().catch(() => {})
+      }
     } else {
       StatusBarNotifNative?.stop().catch(() => {})
     }
@@ -490,11 +495,18 @@ function App() {
     localStorage.setItem('briodo-statusBarContentStyle', val)
   }
 
-  // 앱 시작 시 알림 서비스 시작
+  // 앱 시작 시 알림 서비스 시작 + 배터리 최적화 예외 1회 요청
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return
     if (localStorage.getItem('briodo-statusBarNotifEnabled') === 'false') return
     StatusBarNotifNative?.start({}).catch(() => {})
+    // 기기 제조사 배터리 최적화가 서비스를 종료하는 것을 방지.
+    // 이미 예외 처리된 경우 다이얼로그 없이 즉시 반환. 앱 설치 후 최초 1회만 표시.
+    if (!localStorage.getItem('briodo-batteryOptAsked')) {
+      StatusBarNotifNative?.requestIgnoreBatteryOptimizations?.()
+        .then(() => localStorage.setItem('briodo-batteryOptAsked', '1'))
+        .catch(() => {})
+    }
   }, [])
 
   // 상태바 알림 ➕ 버튼 → SmartInputModal 열기


### PR DESCRIPTION
[상태바 서비스 재시작 문제]
- BootReceiver.java 신규 생성: BOOT_COMPLETED / QUICKBOOT_POWERON 수신 시
  SharedPreferences enabled=true 확인 후 StatusBarNotificationService 자동 재시작
- AndroidManifest.xml: BootReceiver 등록
- StatusBarNotificationPlugin: start()/stop()에서 enabled 상태를 SharedPreferences에 저장

[날씨 텍스트 간헐적 초기화]
- updateContent() 호출 시 알림 본문을 SharedPreferences에도 저장
- StatusBarNotificationService.onCreate(): 프로세스 재시작(배터리 최적화 강제 종료 +
  START_STICKY 복원, BootReceiver 기동) 시 마지막 텍스트 복원

[배터리 최적화 대응]
- REQUEST_IGNORE_BATTERY_OPTIMIZATIONS 권한 추가
- requestIgnoreBatteryOptimizations() / isIgnoringBatteryOptimizations() 메서드 추가
- App.jsx: 상태바 알림 활성화 시 + 앱 최초 1회(기존 사용자 포함) 자동 요청

https://claude.ai/code/session_01T7qxXQKXNNcEJxMcxEkMcD