### PR TITLE
feat: 잔디 심기(GrassGrid) + 업적 달성 공유 기능 구현 (Issue #138, #135)

### DIFF
--- a/PROJECT_HISTORY.md
+++ b/PROJECT_HISTORY.md
@@ -4,6 +4,35 @@
 
 ---
 
+## 2026-04-15 — 잔디 심기(GrassGrid) + 업적 달성 공유 기능 (세션 48)
+
+### 변경 내용
+
+#### 잔디 심기 — GrassGrid 컴포넌트 (Issue #138)
+- `CollectionsScreen.jsx`의 Stats 섹션에 GitHub 스타일 Contribution Heatmap 추가
+- 최근 16주(112일) 완료 데이터를 7행×N열 그리드로 시각화
+- 완료 수 기반 4단계 색상 강도 (0 / 1~2 / 3~4 / 5+)
+- 오늘 셀 강조 outline, 탭 시 날짜·완료 수 툴팁 표시
+- 월 레이블·요일 레이블·범례 포함
+- streak > 0이면 "🔥 N일 연속 달성 중" 배지 표시
+- 새 패키지 미사용 — 기존 React + CSS만으로 구현
+
+#### 업적 달성 공유 — Canvas Share Card (Issue #135)
+- `AchievementUnlockModal.jsx`에 "공유하기 ↗" 버튼 추가
+- `shareAchievementCard()` 함수: Canvas API로 800×480px 공유 카드 생성
+  - 현재 테마 CSS 변수(`--color-primary`, `--color-surface`)를 읽어 테마 반영
+  - 업적 이모지·이름·설명·별점·BrioDo 브랜딩 렌더링
+- Web Share API(`navigator.share({ files: [...] })`) 우선 시도 → 미지원 시 텍스트 공유 → 최종 폴백 이미지 다운로드
+- `html2canvas`, `@capacitor/share` 추가 패키지 없이 구현 (canvas-confetti 사례로 WebView Canvas 안정성 확인)
+- 공유 중 버튼 비활성화 처리로 중복 탭 방지
+
+### 수정 파일
+- `src/components/CollectionsScreen.jsx` — GrassGrid 컴포넌트 + grassData useMemo
+- `src/components/AchievementUnlockModal.jsx` — shareAchievementCard 함수 + 공유 버튼
+- `src/index.css` — `.grass-*` 스타일 + `.ach-share-btn` 스타일
+
+---
+
 ## 2026-04-13 — 보안 강화: Gemini API Cloud Functions 마이그레이션 (세션 47)
 
 ### 변경 내용

--- a/src/components/AchievementUnlockModal.jsx
+++ b/src/components/AchievementUnlockModal.jsx
@@ -1,5 +1,126 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import confetti from 'canvas-confetti'
+
+async function shareAchievementCard(achievement, lang) {
+  const W = 800, H = 480
+  const canvas = document.createElement('canvas')
+  canvas.width = W
+  canvas.height = H
+  const ctx = canvas.getContext('2d')
+
+  // 현재 테마 색상 읽기
+  const style = getComputedStyle(document.documentElement)
+  const primary = style.getPropertyValue('--color-primary').trim() || '#6750A4'
+  const surface = style.getPropertyValue('--color-surface').trim() || '#1C1B1F'
+
+  // 배경 그라디언트
+  const grad = ctx.createLinearGradient(0, 0, W, H)
+  grad.addColorStop(0, surface)
+  grad.addColorStop(1, primary + '55')
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, W, H)
+
+  // 둥근 테두리 효과
+  ctx.strokeStyle = primary + '88'
+  ctx.lineWidth = 3
+  const r = 24
+  ctx.beginPath()
+  ctx.moveTo(r, 0)
+  ctx.lineTo(W - r, 0)
+  ctx.quadraticCurveTo(W, 0, W, r)
+  ctx.lineTo(W, H - r)
+  ctx.quadraticCurveTo(W, H, W - r, H)
+  ctx.lineTo(r, H)
+  ctx.quadraticCurveTo(0, H, 0, H - r)
+  ctx.lineTo(0, r)
+  ctx.quadraticCurveTo(0, 0, r, 0)
+  ctx.closePath()
+  ctx.stroke()
+
+  // 이모지 (대형)
+  ctx.font = '96px serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(achievement.icon || '🏆', W / 2, 130)
+
+  // 업적 달성 레이블
+  const titleText = achievement.hidden
+    ? (lang === 'ko' ? '🔮 비밀 업적 해제!' : lang === 'ja' ? '🔮 秘密実績解除！' : lang === 'zh' ? '🔮 秘密成就解锁！' : '🔮 Secret Achievement!')
+    : (lang === 'ko' ? '업적 달성!' : lang === 'ja' ? '実績解除！' : lang === 'zh' ? '成就解锁！' : 'Achievement Unlocked!')
+  ctx.font = 'bold 28px sans-serif'
+  ctx.fillStyle = primary
+  ctx.fillText(titleText, W / 2, 230)
+
+  // 업적 이름
+  const name = achievement.name?.[lang] || achievement.name?.ko || ''
+  ctx.font = 'bold 38px sans-serif'
+  ctx.fillStyle = '#ffffff'
+  ctx.fillText(name, W / 2, 285)
+
+  // 설명 (긴 경우 줄바꿈)
+  const desc = achievement.desc?.[lang] || achievement.desc?.ko || ''
+  ctx.font = '20px sans-serif'
+  ctx.fillStyle = 'rgba(255,255,255,0.72)'
+  const maxWidth = W - 80
+  const words = desc.split(' ')
+  let line = ''
+  let lineY = 335
+  for (const word of words) {
+    const testLine = line + (line ? ' ' : '') + word
+    if (ctx.measureText(testLine).width > maxWidth && line) {
+      ctx.fillText(line, W / 2, lineY)
+      line = word
+      lineY += 28
+      if (lineY > 390) break
+    } else {
+      line = testLine
+    }
+  }
+  if (line) ctx.fillText(line, W / 2, lineY)
+
+  // 별점
+  const stars = Math.ceil((achievement.difficulty || 1) / 2)
+  ctx.font = '22px serif'
+  ctx.fillStyle = '#FFD700'
+  const starStr = '★'.repeat(stars) + '☆'.repeat(5 - stars)
+  ctx.fillText(starStr, W / 2, Math.min(lineY + 36, 420))
+
+  // 하단 브랜딩
+  ctx.font = 'bold 16px sans-serif'
+  ctx.fillStyle = 'rgba(255,255,255,0.45)'
+  ctx.fillText('BrioDo · Do it with brio.', W / 2, H - 24)
+
+  return new Promise((resolve) => {
+    canvas.toBlob(async (blob) => {
+      if (!blob) { resolve(false); return }
+      const name2 = achievement.name?.[lang] || achievement.name?.ko || 'achievement'
+      const shareText = lang === 'ko'
+        ? `BrioDo에서 "${name2}" 업적을 달성했어요! 🎉`
+        : lang === 'ja' ? `BrioDo で「${name2}」実績を解除しました！ 🎉`
+        : lang === 'zh' ? `在 BrioDo 中解锁了「${name2}」成就！ 🎉`
+        : `I just unlocked "${name2}" on BrioDo! 🎉`
+      const file = new File([blob], 'briodo-achievement.png', { type: 'image/png' })
+      try {
+        if (navigator.canShare?.({ files: [file] })) {
+          await navigator.share({ files: [file], title: 'BrioDo', text: shareText })
+        } else if (navigator.share) {
+          await navigator.share({ title: 'BrioDo', text: shareText })
+        } else {
+          // 폴백: 이미지 다운로드
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = 'briodo-achievement.png'
+          a.click()
+          URL.revokeObjectURL(url)
+        }
+        resolve(true)
+      } catch {
+        resolve(false)
+      }
+    }, 'image/png')
+  })
+}
 
 const PARTICLES = [
   { tx: -70, ty: -100, color: '#FFD700', delay: 0 },
@@ -20,11 +141,20 @@ export function AchievementUnlockModal({ achievement, onDismiss, lang }) {
   const [visible, setVisible] = useState(false)
   // localAchievement: achievement prop이 null이 돼도 exit 애니메이션 동안 렌더링 유지
   const [localAchievement, setLocalAchievement] = useState(null)
+  const [isSharing, setIsSharing] = useState(false)
   const rafRef = useRef(null)
   const confettiTimerRef = useRef(null)
   // 고정 캔버스 ref — 마운트 시 1회만 생성, 업적마다 재생성 없음
   const canvasRef = useRef(null)
   const confettiRef = useRef(null)
+
+  const handleShare = useCallback(async (e) => {
+    e.stopPropagation()
+    if (!localAchievement || isSharing) return
+    setIsSharing(true)
+    await shareAchievementCard(localAchievement, lang)
+    setIsSharing(false)
+  }, [localAchievement, lang, isSharing])
 
   // 마운트 시 confetti 인스턴스를 고정 캔버스에 바인딩 (이후 캔버스 재생성 없음)
   // 캔버스를 항상 DOM에 유지하면 Android WebView의 GPU 레이어 재생성 → 흰 플래시 없음
@@ -140,6 +270,11 @@ export function AchievementUnlockModal({ achievement, onDismiss, lang }) {
             <div className="ach-unlock-difficulty">
               {'★'.repeat(Math.ceil(localAchievement.difficulty / 2))}{'☆'.repeat(5 - Math.ceil(localAchievement.difficulty / 2))}
             </div>
+            <button className="ach-share-btn" onClick={handleShare} disabled={isSharing}>
+              {isSharing
+                ? (lang === 'ko' ? '공유 중...' : lang === 'ja' ? '共有中...' : lang === 'zh' ? '分享中...' : 'Sharing...')
+                : (lang === 'ko' ? '공유하기 ↗' : lang === 'ja' ? 'シェアする ↗' : lang === 'zh' ? '分享 ↗' : 'Share ↗')}
+            </button>
             <div className="ach-unlock-tap" onClick={() => dismiss(localAchievement)}>
               {lang === 'ko' ? '탭하여 닫기' : lang === 'ja' ? 'タップして閉じる' : lang === 'zh' ? '点击关闭' : 'Tap to close'}
             </div>

--- a/src/components/CollectionsScreen.jsx
+++ b/src/components/CollectionsScreen.jsx
@@ -1,5 +1,152 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { calcStreak } from '../utils/helpers'
+
+// ─── GrassGrid 컴포넌트 ───
+function GrassGrid({ grassData, todayStr, streak, lang }) {
+  const tooltipRef = useRef(null)
+  const [tooltip, setTooltip] = useState(null) // { date, completed, x, y }
+
+  // grassData를 주 단위로 묶기
+  // 오늘이 속한 주의 마지막 날까지 포함되도록 패딩
+  const weeks = useMemo(() => {
+    if (!grassData || grassData.length === 0) return []
+    // 첫 날의 요일(0=일, 1=월, ...) 기준으로 앞에 빈 셀 패딩
+    const firstDate = new Date(grassData[0].date + 'T00:00:00')
+    // 월요일 기준(0=월, 6=일)
+    const firstDow = (firstDate.getDay() + 6) % 7 // Mon=0, Sun=6
+    const padded = []
+    for (let i = 0; i < firstDow; i++) padded.push(null)
+    padded.push(...grassData)
+    // 뒤에도 일요일까지 채우기
+    while (padded.length % 7 !== 0) padded.push(null)
+    const result = []
+    for (let w = 0; w < padded.length / 7; w++) {
+      result.push(padded.slice(w * 7, w * 7 + 7))
+    }
+    return result
+  }, [grassData])
+
+  // 각 주 첫 날 기준 월 레이블
+  const monthLabels = useMemo(() => {
+    return weeks.map(week => {
+      const firstDay = week.find(d => d !== null)
+      if (!firstDay) return ''
+      const d = new Date(firstDay.date + 'T00:00:00')
+      if (d.getDate() <= 7) {
+        return (d.getMonth() + 1) + (lang === 'ko' ? '월' : lang === 'ja' ? '月' : lang === 'zh' ? '月' : '')
+      }
+      return ''
+    })
+  }, [weeks, lang])
+
+  const dayLabels = lang === 'ko' ? ['월', '', '수', '', '금', '', '일']
+    : lang === 'ja' ? ['月', '', '水', '', '金', '', '日']
+    : lang === 'zh' ? ['一', '', '三', '', '五', '', '日']
+    : ['M', '', 'W', '', 'F', '', 'S']
+
+  const getCellLevel = (completed) => {
+    if (!completed || completed === 0) return 0
+    if (completed <= 2) return 1
+    if (completed <= 4) return 2
+    return 3
+  }
+
+  const handleCellTap = (day, e) => {
+    if (!day) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    setTooltip(prev =>
+      prev?.date === day.date ? null : { date: day.date, completed: day.completed, x: rect.left, y: rect.top }
+    )
+  }
+
+  const streakText = streak > 0
+    ? (lang === 'ko' ? `🔥 ${streak}일 연속 달성 중`
+      : lang === 'ja' ? `🔥 ${streak}日連続達成中`
+      : lang === 'zh' ? `🔥 连续${streak}天达成`
+      : `🔥 ${streak}-day streak`)
+    : (lang === 'ko' ? '오늘부터 연속 달성을 시작해보세요!'
+      : lang === 'ja' ? '今日から連続達成を始めましょう！'
+      : lang === 'zh' ? '从今天开始连续达成！'
+      : 'Start your streak today!')
+
+  return (
+    <div className="grass-section" onClick={() => setTooltip(null)}>
+      <div className="grass-section-header">
+        <span className="grass-streak-badge">{streakText}</span>
+      </div>
+      <div className="grass-scroll-wrap">
+        <div className="grass-grid-container">
+          {/* 월 레이블 행 */}
+          <div className="grass-month-row">
+            {weeks.map((_, wi) => (
+              <div key={wi} className="grass-month-label">{monthLabels[wi]}</div>
+            ))}
+          </div>
+          {/* 요일 레이블 + 잔디 셀 */}
+          <div className="grass-body">
+            <div className="grass-day-labels">
+              {dayLabels.map((d, i) => (
+                <div key={i} className="grass-day-label">{d}</div>
+              ))}
+            </div>
+            <div className="grass-columns">
+              {weeks.map((week, wi) => (
+                <div key={wi} className="grass-col">
+                  {week.map((day, di) => {
+                    if (!day) return <div key={di} className="grass-cell" style={{ opacity: 0 }} />
+                    const level = getCellLevel(day.completed)
+                    const isToday = day.date === todayStr
+                    return (
+                      <div
+                        key={di}
+                        className={`grass-cell level-${level}${isToday ? ' is-today' : ''}`}
+                        onClick={e => { e.stopPropagation(); handleCellTap(day, e) }}
+                      />
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* 툴팁 */}
+      {tooltip && (
+        <div
+          ref={tooltipRef}
+          style={{
+            position: 'fixed',
+            top: Math.max(8, tooltip.y - 44),
+            left: Math.min(tooltip.x - 20, window.innerWidth - 160),
+            background: 'var(--color-surface-container-highest)',
+            color: 'var(--color-on-surface)',
+            borderRadius: 8,
+            padding: '5px 10px',
+            fontSize: 12,
+            fontWeight: 600,
+            zIndex: 9999,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.18)',
+            pointerEvents: 'none',
+          }}
+        >
+          {tooltip.date} · {tooltip.completed > 0
+            ? (lang === 'ko' ? `${tooltip.completed}개 완료` : lang === 'ja' ? `${tooltip.completed}件完了` : lang === 'zh' ? `完成${tooltip.completed}项` : `${tooltip.completed} done`)
+            : (lang === 'ko' ? '완료 없음' : lang === 'ja' ? '完了なし' : lang === 'zh' ? '无完成' : 'None')}
+        </div>
+      )}
+      {/* 범례 */}
+      <div className="grass-legend">
+        <span className="grass-legend-label">{lang === 'ko' ? '적음' : lang === 'ja' ? '少' : lang === 'zh' ? '少' : 'Less'}</span>
+        <div className="grass-legend-cells">
+          {[0,1,2,3].map(lv => (
+            <div key={lv} className={`grass-legend-cell grass-cell level-${lv}`} />
+          ))}
+        </div>
+        <span className="grass-legend-label">{lang === 'ko' ? '많음' : lang === 'ja' ? '多' : lang === 'zh' ? '多' : 'More'}</span>
+      </div>
+    </div>
+  )
+}
 
 const ACCENT_COLORS = [
   { cls: 'coll-indigo',  emoji: '💼' },
@@ -59,6 +206,19 @@ export function CollectionsScreen({ todos, t, lang, openEditModal, toggleComplet
     const streak = calcStreak(todos, todayStr)
     return { todayDone, weekDone, streak }
   }, [todos, todayStr, weeklyPulse])
+
+  // 잔디 데이터: 최근 16주(112일)
+  const grassData = useMemo(() => {
+    const days = []
+    for (let i = 111; i >= 0; i--) {
+      const d = new Date()
+      d.setDate(d.getDate() - i)
+      const dateStr = d.toISOString().slice(0, 10)
+      const completed = todos.filter(t => t.completed && t.date === dateStr).length
+      days.push({ date: dateStr, completed })
+    }
+    return days
+  }, [todos])
 
   const allRate = allTotal > 0 ? allDone / allTotal : 0
   const circum = 2 * Math.PI * 28
@@ -215,6 +375,14 @@ export function CollectionsScreen({ todos, t, lang, openEditModal, toggleComplet
             </div>
           </div>
         )}
+
+        {/* 잔디 심기 */}
+        <GrassGrid
+          grassData={grassData}
+          todayStr={todayStr}
+          streak={stats.streak}
+          lang={lang}
+        />
 
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -4499,3 +4499,142 @@ body.modal-open { overflow: hidden; }
   animation: weekSlideFromLeft 0.22s ease;
 }
 .week-strip { overflow: hidden; }
+
+/* ─── Grass Grid (잔디 심기) ─── */
+.grass-section {
+  margin: 12px 0 4px;
+}
+.grass-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.grass-streak-badge {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  border-radius: 20px;
+  padding: 3px 10px;
+  letter-spacing: -0.2px;
+}
+.grass-scroll-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding-bottom: 4px;
+}
+.grass-scroll-wrap::-webkit-scrollbar { display: none; }
+.grass-grid-container {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: max-content;
+}
+.grass-month-row {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 3px;
+  padding-left: 18px;
+}
+.grass-month-label {
+  font-size: 9px;
+  color: var(--color-on-surface-variant);
+  opacity: 0.6;
+  min-width: 14px;
+  text-align: left;
+  letter-spacing: -0.3px;
+}
+.grass-body {
+  display: flex;
+  gap: 3px;
+}
+.grass-day-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-right: 0;
+}
+.grass-day-label {
+  width: 16px;
+  height: 14px;
+  font-size: 9px;
+  color: var(--color-on-surface-variant);
+  opacity: 0.5;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 2px;
+}
+.grass-columns {
+  display: flex;
+  gap: 3px;
+}
+.grass-col {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.grass-cell {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: var(--color-surface-container-high);
+  transition: transform 0.1s;
+}
+.grass-cell.level-1 {
+  background: color-mix(in srgb, var(--color-primary) 28%, transparent);
+}
+.grass-cell.level-2 {
+  background: color-mix(in srgb, var(--color-primary) 58%, transparent);
+}
+.grass-cell.level-3 {
+  background: var(--color-primary);
+}
+.grass-cell.is-today {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -1px;
+}
+.grass-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  justify-content: flex-end;
+}
+.grass-legend-label {
+  font-size: 10px;
+  color: var(--color-on-surface-variant);
+  opacity: 0.55;
+}
+.grass-legend-cells {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+}
+.grass-legend-cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+}
+
+/* ─── Achievement Share Button ─── */
+.ach-share-btn {
+  margin-top: 8px;
+  padding: 8px 24px;
+  border-radius: 20px;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  transition: background 0.15s, transform 0.1s;
+}
+.ach-share-btn:active {
+  transform: scale(0.96);
+  background: rgba(255, 255, 255, 0.25);
+}


### PR DESCRIPTION
- CollectionsScreen Stats 섹션에 GitHub 스타일 Contribution Heatmap 추가
  - 최근 16주(112일) 완료 데이터 4단계 색상 강도로 시각화
  - 오늘 셀 강조, 탭 시 날짜·완료 수 툴팁, 월/요일 레이블·범례
  - 연속 달성 streak 배지 표시 (🔥 N일 연속 달성 중)
- AchievementUnlockModal에 공유하기 버튼 추가
  - Canvas API로 800×480px 테마 반영 공유 카드 생성
  - Web Share API(파일 우선) → 텍스트 공유 → 이미지 다운로드 폴백
  - 추가 패키지 없이 구현

https://claude.ai/code/session_01LQXWUQfbqBSxHCSVd8E172